### PR TITLE
v0.18.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.18.1 (2020-03-02)
+
+- Update links to point to new repository location
+- signatory-secp256k1: update `secp256k1` requirement from 0.15 to 0.17
+- signatory-secp256k1: support Ethereum's `Keccak256` hash function for signing
+
 ## 0.18.0 (2020-01-19)
 
 - Upgrade `ecdsa` crate to v0.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,13 +846,12 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "ecdsa 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,50 +859,51 @@ dependencies = [
 
 [[package]]
 name = "signatory-dalek"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.18.0",
+ "signatory 0.18.1",
 ]
 
 [[package]]
 name = "signatory-ledger-tm"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ledger-tendermint 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.18.0",
+ "signatory 0.18.1",
 ]
 
 [[package]]
 name = "signatory-ring"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.18.0",
+ "signatory 0.18.1",
 ]
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.18.0",
+ "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.18.1",
  "signature 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "signatory-sodiumoxide"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.18.0",
+ "signatory 0.18.1",
  "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -22,7 +22,6 @@ getrandom = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
 signature = { version = "= 1.0.0-pre.1", default-features = false }
 zeroize = { version = "1", default-features = false }
-sha3 = "0.8"
 
 [dependencies.subtle-encoding]
 version = "0.4"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 
-A pure Rust multi-provider digital signature library with support for elliptic
+Pure Rust multi-provider digital signature library with support for elliptic
 curve digital signature algorithms, namely ECDSA (described in [FIPS 186‑4])
 and Ed25519 (described in [RFC 8032]).
 

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/signatory-dalek/src/lib.rs
+++ b/signatory-dalek/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.18.0"
+    html_root_url = "https://docs.rs/signatory-dalek/0.18.1"
 )]
 
 #[cfg(test)]

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-tm"
 description = "Signatory provider for Ledger Tendermint Validator app"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/signatory-ledger-tm/src/lib.rs
+++ b/signatory-ledger-tm/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-tm/0.18.0"
+    html_root_url = "https://docs.rs/signatory-ledger-tm/0.18.1"
 )]
 
 use ledger_tendermint::ledgertm::TendermintValidatorApp;

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.18.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.18.1"
 )]
 
 #[cfg(test)]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -16,6 +16,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 secp256k1 = "0.17"
+sha3 = { version = "0.8", optional = true }
 signature = { version = "= 1.0.0-pre.1", features = ["derive-preview"] }
 
 [dependencies.signatory]

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.18.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.18.1"
 )]
 
 pub use signatory;
@@ -14,9 +14,11 @@ use secp256k1::{self, Secp256k1, SignOnly, VerifyOnly};
 use signatory::{
     public_key::PublicKeyed,
     sha2::Sha256,
-    sha3::Keccak256,
     signature::{digest::Digest, DigestSigner, DigestVerifier, Error, Signature, Signer, Verifier},
 };
+
+#[cfg(feature = "sha3")]
+use sha3::Keccak256;
 
 /// ECDSA signature provider for the secp256k1 crate
 #[derive(Signer)]
@@ -63,6 +65,7 @@ impl DigestSigner<Sha256, FixedSignature> for EcdsaSigner {
     }
 }
 
+#[cfg(feature = "sha3")]
 impl DigestSigner<Keccak256, FixedSignature> for EcdsaSigner {
     fn try_sign_digest(&self, digest: Keccak256) -> Result<FixedSignature, Error> {
         Ok(

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.18.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.18.1" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.18.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.18.1"
 )]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.18.0"
+    html_root_url = "https://docs.rs/signatory/0.18.1"
 )]
 
 #[cfg(feature = "alloc")]
@@ -89,5 +89,4 @@ pub mod test_vector;
 pub use generic_array;
 #[cfg(feature = "sha2")]
 pub use sha2;
-pub use sha3;
 pub use signature;


### PR DESCRIPTION
- Update links to point to new repository location
- signatory-secp256k1: update `secp256k1` requirement from 0.15 to 0.17
- signatory-secp256k1: support Ethereum's `Keccak256` hash function for signing