### PR TITLE
v0.20.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -151,7 +151,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
@@ -200,7 +200,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
@@ -267,7 +267,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
@@ -334,7 +334,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
@@ -401,7 +401,7 @@ jobs:
           - windows-latest
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources
@@ -464,7 +464,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.41.0
+          - 1.42.0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 0.20.0 (2020-06-10)
+
+- Bump `ecdsa`, `sha2`, `sha3`, and `signature`; MSRV 1.41+ ([#30])
+- signatory-dalek: remove Ed25519ph (DigestSigner/DigestVerifier) (#29)
+
+[#30]: https://github.com/iqlusioninc/signatory/pull/30
+[#29]: https://github.com/iqlusioninc/signatory/pull/29
+
 ## 0.19.0 (2020-04-19)
 
 - Update `signature` crate requirement to v1.0.1 ([#14])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,12 +576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ecdsa",
  "ed25519",
@@ -982,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-dalek"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "ed25519-dalek",
@@ -991,14 +985,13 @@ dependencies = [
 
 [[package]]
 name = "signatory-ledger-tm"
-version = "0.19.1"
+version = "0.20.0"
 dependencies = [
  "byteorder",
  "criterion",
  "ed25519-dalek",
  "lazy_static",
  "ledger",
- "matches",
  "sha2 0.8.2",
  "signatory",
  "thiserror",
@@ -1006,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-ring"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "ring",
@@ -1015,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "secp256k1",
@@ -1026,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-sodiumoxide"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "criterion",
  "signatory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ specific providers selected at runtime.
 
 ## Minimum Supported Rust Version
 
-All Signatory providers require Rust **1.41+**
+All Signatory providers require Rust **1.42+**
 
 ## Provider Support
 
@@ -72,7 +72,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [docs-image]: https://docs.rs/signatory/badge.svg
 [docs-link]: https://docs.rs/signatory/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.42+-blue.svg
 [build-image]: https://github.com/iqlusioninc/signatory/workflows/Rust/badge.svg?branch=develop&event=push
 [build-link]: https://github.com/iqlusioninc/signatory/actions
 

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 ed25519-dalek = { version = "= 1.0.0-pre.2", default-features = false }
 
 [dependencies.signatory]
-version = "0.19"
+version = "0.20"
 default-features = false
 features = ["digest", "ed25519"]
 path = ".."
@@ -27,7 +27,7 @@ path = ".."
 criterion = "0.3"
 
 [dev-dependencies.signatory]
-version = "0.19"
+version = "0.20"
 default-features = false
 features = ["digest", "ed25519", "test-vectors"]
 path = ".."

--- a/signatory-dalek/src/lib.rs
+++ b/signatory-dalek/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.19.0"
+    html_root_url = "https://docs.rs/signatory-dalek/0.20.0"
 )]
 
 use signatory::{

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-tm"
 description = "Signatory provider for Ledger Tendermint Validator app"
-version     = "0.19.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/ZondaX/ledger-tendermint-rs"
@@ -17,11 +17,10 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 byteorder = "1.3.1"
 ledger = "0.2.5"
-matches = "0.1.8"
 thiserror = "1"
 
 [dependencies.signatory]
-version = "0.19"
+version = "0.20"
 features = ["digest", "ed25519"]
 path = ".."
 

--- a/signatory-ledger-tm/src/lib.rs
+++ b/signatory-ledger-tm/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-tm/0.19.1"
+    html_root_url = "https://docs.rs/signatory-ledger-tm/0.20.0"
 )]
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 ring = { version = "0.16", default-features = false }
 
 [dependencies.signatory]
-version = "0.19"
+version = "0.20"
 default-features = false
 features = ["pkcs8"]
 path = ".."
@@ -27,7 +27,7 @@ path = ".."
 criterion = "0.3"
 
 [dev-dependencies.signatory]
-version = "0.19"
+version = "0.20"
 default-features = false
 features = ["pkcs8", "test-vectors"]
 path = ".."

--- a/signatory-ring/src/ed25519.rs
+++ b/signatory-ring/src/ed25519.rs
@@ -84,5 +84,5 @@ impl signature::Verifier<Signature> for Verifier {
 #[cfg(test)]
 mod tests {
     use super::{Signer, Verifier};
-    ed25519_tests!(Signer, Verifier);
+    signatory::ed25519_tests!(Signer, Verifier);
 }

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,16 +5,12 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.19.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.20.0"
 )]
 
 #[cfg(test)]
 #[macro_use]
 extern crate std;
-
-#[cfg(all(test, feature = "ed25519"))]
-#[macro_use]
-extern crate signatory;
 
 /// ECDSA signing and verification support
 #[cfg(feature = "ecdsa")]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -20,7 +20,7 @@ sha3 = { version = "0.9", optional = true }
 signature = { version = "1.1.0", features = ["derive-preview"] }
 
 [dependencies.signatory]
-version = "0.19"
+version = "0.20"
 features = ["digest", "ecdsa", "k256", "sha2"]
 path = ".."
 
@@ -28,7 +28,7 @@ path = ".."
 criterion = "0.3"
 
 [dev-dependencies.signatory]
-version = "0.19"
+version = "0.20"
 default-features = false
 features = ["digest", "ecdsa", "k256", "sha2", "test-vectors"]
 path = ".."

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.19.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.20.0"
 )]
 
 pub use signatory;

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.19.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 sodiumoxide = "0.2"
 
 [dependencies.signatory]
-version = "0.19"
+version = "0.20"
 features = ["ed25519", "test-vectors"]
 path = ".."
 

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,12 +5,8 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.19.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.20.0"
 )]
-
-#[cfg(test)]
-#[macro_use]
-extern crate signatory;
 
 use signatory::{
     ed25519,
@@ -76,5 +72,5 @@ impl Verifier<ed25519::Signature> for Ed25519Verifier {
 #[cfg(test)]
 mod tests {
     use super::{Ed25519Signer, Ed25519Verifier};
-    ed25519_tests!(Ed25519Signer, Ed25519Verifier);
+    signatory::ed25519_tests!(Ed25519Signer, Ed25519Verifier);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.19.0"
+    html_root_url = "https://docs.rs/signatory/0.20.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
- Bump `ecdsa`, `sha2`, `sha3`, and `signature`; MSRV 1.41+ ([#30])
- signatory-dalek: remove Ed25519ph (DigestSigner/DigestVerifier) (#29)

[#30]: https://github.com/iqlusioninc/signatory/pull/30
[#29]: https://github.com/iqlusioninc/signatory/pull/29