### PR TITLE
v0.21.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,15 @@
+## 0.21.0 (2020-08-12)
+
+- Bump `ecdsa` dependency to v0.7 ([#42])
+- signatory-dalek: deprecate in favor of `ed25519-dalek` ([#40])
+
+[#42]: https://github.com/iqlusioninc/signatory/pull/42
+[#40]: https://github.com/iqlusioninc/signatory/pull/40
+
 ## 0.20.0 (2020-06-10)
 
 - Bump `ecdsa`, `sha2`, `sha3`, and `signature`; MSRV 1.41+ ([#30])
-- signatory-dalek: remove Ed25519ph (DigestSigner/DigestVerifier) (#29)
+- signatory-dalek: remove Ed25519ph (DigestSigner/DigestVerifier) ([#29])
 
 [#30]: https://github.com/iqlusioninc/signatory/pull/30
 [#29]: https://github.com/iqlusioninc/signatory/pull/29

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "ecdsa",
  "ed25519",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-ledger-tm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "byteorder",
  "criterion",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-ring"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "ring",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "k256",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "signatory-sodiumoxide"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "criterion",
  "signatory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-tm"
 description = "Signatory provider for Ledger Tendermint Validator app"
-version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/ZondaX/ledger-tendermint-rs"
@@ -17,7 +17,7 @@ ledger = "0.2.5"
 thiserror = "1"
 
 [dependencies.signatory]
-version = "0.20"
+version = "0.21"
 features = ["digest", "ed25519"]
 path = ".."
 

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -13,11 +13,11 @@ edition     = "2018"
 
 [dependencies]
 ring = { version = "0.16", default-features = false }
-signatory = { version = "0.20",  default-features = false, features = ["pkcs8"], path = ".." }
+signatory = { version = "0.21",  default-features = false, features = ["pkcs8"], path = ".." }
 
 [dev-dependencies]
 criterion = "0.3"
-signatory = { version = "0.20",  default-features = false, features = ["pkcs8", "test-vectors"], path = ".." }
+signatory = { version = "0.21",  default-features = false, features = ["pkcs8", "test-vectors"], path = ".." }
 
 [features]
 default = ["ecdsa", "ed25519", "std"]

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.20.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.21.0"
 )]
 
 #[cfg(test)]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -15,12 +15,12 @@ edition     = "2018"
 k256 = { version = "0.4", default-features = false, features = ["ecdsa"] }
 secp256k1 = "0.17"
 sha3 = { version = "0.9", optional = true }
-signatory = { version = "0.20", features = ["digest", "ecdsa", "k256", "sha2"], path = ".." }
+signatory = { version = "0.21", features = ["digest", "ecdsa", "k256", "sha2"], path = ".." }
 signature = { version = "1", features = ["derive-preview"] }
 
 [dev-dependencies]
 criterion = "0.3"
-signatory = { version = "0.20", features = ["digest", "ecdsa", "k256", "sha2", "test-vectors"], path = ".." }
+signatory = { version = "0.21", features = ["digest", "ecdsa", "k256", "sha2", "test-vectors"], path = ".." }
 
 [[bench]]
 name = "ecdsa"

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.20.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.21.0"
 )]
 
 pub use signatory;

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.20.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.21.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/signatory"
@@ -13,11 +13,11 @@ edition     = "2018"
 
 [dependencies]
 sodiumoxide = "0.2"
-signatory = { version = "0.20", features = ["ed25519"], path = ".." }
+signatory = { version = "0.21", features = ["ed25519"], path = ".." }
 
 [dev-dependencies]
 criterion = "0.3"
-signatory = { version = "0.20", features = ["ed25519", "test-vectors"], path = ".." }
+signatory = { version = "0.21", features = ["ed25519", "test-vectors"], path = ".." }
 
 [[bench]]
 name = "ed25519"

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.20.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.21.0"
 )]
 
 use signatory::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iqlusioninc/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.20.0"
+    html_root_url = "https://docs.rs/signatory/0.21.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
- Bump `ecdsa` dependency to v0.7 ([#42])
- signatory-dalek: deprecate in favor of `ed25519-dalek` ([#40])

[#42]: https://github.com/iqlusioninc/signatory/pull/42
[#40]: https://github.com/iqlusioninc/signatory/pull/40