### PR TITLE
Remove `PublicKeyed` trait

### DIFF
--- a/signatory-ledger-tm/benches/ed25519.rs
+++ b/signatory-ledger-tm/benches/ed25519.rs
@@ -10,7 +10,6 @@ use signatory;
 use criterion::Criterion;
 use signatory::{
     ed25519,
-    public_key::PublicKeyed,
     signature::{Signature, Verifier},
 };
 use signatory_ledger_tm::Ed25519LedgerTmAppSigner;

--- a/signatory-ring/src/ed25519.rs
+++ b/signatory-ring/src/ed25519.rs
@@ -2,14 +2,8 @@
 
 pub use signatory::ed25519::{PublicKey, Seed, Signature};
 
-use ring::{
-    self,
-    signature::{Ed25519KeyPair, KeyPair, UnparsedPublicKey},
-};
-use signatory::{
-    public_key::PublicKeyed,
-    signature::{self, Signature as _},
-};
+use ring::signature::{Ed25519KeyPair, KeyPair, UnparsedPublicKey};
+use signatory::signature::{self, Signature as _};
 
 #[cfg(feature = "std")]
 use ring::rand::SystemRandom;
@@ -22,11 +16,10 @@ use signatory::encoding::{
 /// Ed25519 signature provider for *ring*
 pub struct Signer(Ed25519KeyPair);
 
-impl<'a> From<&'a Seed> for Signer {
+impl From<&Seed> for Signer {
     /// Create a new Ed25519Signer from an unexpanded seed value
-    fn from(seed: &'a Seed) -> Self {
+    fn from(seed: &Seed) -> Self {
         let keypair = Ed25519KeyPair::from_seed_unchecked(seed.as_secret_slice()).unwrap();
-
         Signer(keypair)
     }
 }
@@ -51,9 +44,9 @@ impl GeneratePkcs8 for Signer {
     }
 }
 
-impl PublicKeyed<PublicKey> for Signer {
-    fn public_key(&self) -> Result<PublicKey, signature::Error> {
-        Ok(PublicKey::from_bytes(self.0.public_key()).unwrap())
+impl From<&Signer> for PublicKey {
+    fn from(signer: &Signer) -> PublicKey {
+        PublicKey::from_bytes(signer.0.public_key()).unwrap()
     }
 }
 

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -10,7 +10,6 @@
 
 use signatory::{
     ed25519,
-    public_key::PublicKeyed,
     signature::{Error, Signature, Signer, Verifier},
 };
 use sodiumoxide::crypto::sign::ed25519::{self as sodiumoxide_ed25519, SecretKey};
@@ -21,9 +20,9 @@ pub struct Ed25519Signer {
     public_key: ed25519::PublicKey,
 }
 
-impl<'a> From<&'a ed25519::Seed> for Ed25519Signer {
+impl From<&ed25519::Seed> for Ed25519Signer {
     /// Create a new SodiumOxideSigner from an unexpanded seed value
-    fn from(seed: &'a ed25519::Seed) -> Self {
+    fn from(seed: &ed25519::Seed) -> Self {
         let sodiumoxide_seed =
             sodiumoxide_ed25519::Seed::from_slice(seed.as_secret_slice()).unwrap();
         let (public_key, secret_key) = sodiumoxide_ed25519::keypair_from_seed(&sodiumoxide_seed);
@@ -35,9 +34,9 @@ impl<'a> From<&'a ed25519::Seed> for Ed25519Signer {
     }
 }
 
-impl PublicKeyed<ed25519::PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<ed25519::PublicKey, Error> {
-        Ok(self.public_key)
+impl From<&Ed25519Signer> for ed25519::PublicKey {
+    fn from(signer: &Ed25519Signer) -> ed25519::PublicKey {
+        signer.public_key
     }
 }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -1,14 +1,6 @@
 //! Traits for public keys
 
 use core::fmt::Debug;
-use signature::Error;
-
-/// Signers which know their public keys (to be implemented by Signatory
-/// providers)
-pub trait PublicKeyed<K: PublicKey>: Send + Sync {
-    /// Public key which can verify signatures created by this signer
-    fn public_key(&self) -> Result<K, Error>;
-}
 
 /// Common trait for all public keys
 pub trait PublicKey: AsRef<[u8]> + Debug + Sized + Eq + Ord {}


### PR DESCRIPTION
...in favor of an `impl From<&Signer> for PublicKey` approach.

There are two main problems with this trait:

- It's defined in `signatory`, which prevents interop with crates that natively support the `signature` traits (e.g. ed25519-dalek)
- It's needlessly fallible. In cases where failure could occur, it would be better to handle that failure in the constructor