### PR TITLE
README.md: remove `yubihsm` crate references

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ All Signatory providers require Rust **1.44+**
 ## Provider Support
 
 Signatory includes the following providers, which are each packaged into their
-own respective crates (except for the [yubihsm] provider, which is included
-[directly in the yubihsm crate]).
+own respective crates:
 
 ### ECDSA providers
 
@@ -38,7 +37,6 @@ own respective crates (except for the [yubihsm] provider, which is included
 | --------------------- | -------------- | ---- | ------ | ------ | ---------- |
 | [signatory‑ring]      | [*ring*]       | Soft | ✅     | ✅     | ⛔         |
 | [signatory‑secp256k1] | [secp256k1]    | Soft | ⛔     | ⛔     | ✅         |
-| [yubihsm]             | [yubihsm]      | Hard | ✅     | ✅     | ✅         |
 
 ### Ed25519 providers
 
@@ -46,7 +44,6 @@ own respective crates (except for the [yubihsm] provider, which is included
 | ----------------------- | --------------- | ---- | ------- | ------------ |
 | [signatory‑ring]        | [*ring*]        | Soft | 47 k/s  | 16 k/s       |
 | [signatory‑sodiumoxide] | [sodiumoxide]   | Soft | 38 k/s  | 15 k/s       |
-| [yubihsm]               | [yubihsm]       | Hard | ~8/s    | N/A          |
 
 ### Tendermint only providers (amino encoded consensus votes)
 
@@ -83,9 +80,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [*ring*]: https://github.com/briansmith/ring
 [secp256k1]: https://github.com/rust-bitcoin/rust-secp256k1/
 [sodiumoxide]: https://github.com/dnaq/sodiumoxide
-[yubihsm]: https://github.com/tendermint/yubihsm-rs
 [ledger-tendermint]: https://crates.io/crates/ledger-tendermint
-[directly in the yubihsm crate]: https://docs.rs/yubihsm/latest/yubihsm/signatory/index.html
 [signatory‑ring]: https://crates.io/crates/signatory-ring
 [signatory‑secp256k1]: https://crates.io/crates/signatory-secp256k1
 [signatory‑sodiumoxide]: https://crates.io/crates/signatory-sodiumoxide

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,6 @@
 //! - [signatory-sodiumoxide]: Ed25519 signing/verification with the
 //!   [sodiumoxide] crate, a Rust wrapper for libsodium (NOTE: requires
 //!   libsodium to be installed on the system)
-//! - [yubihsm-rs]: ECDSA and Ed25519 signing provider support for
-//!   private keys stored in a `YubiHSM2` hardware device, via the
-//!   Signatory signers types in the [yubihsm-rs] crate
-//!   ([yubihsm::ecdsa::Signer] and [yubihsm::ed25519::Signer]).
 //!
 //! ## Signing API
 //!
@@ -49,9 +45,6 @@
 //! [libsecp256k1]: https://docs.rs/crate/secp256k1
 //! [signatory-sodiumoxide]: https://docs.rs/crate/signatory-sodiumoxide/
 //! [sodiumoxide]: https://docs.rs/crate/sodiumoxide/
-//! [yubihsm-rs]: https://docs.rs/crate/yubihsm/
-//! [yubihsm::ecdsa::Signer]: https://docs.rs/yubihsm/latest/yubihsm/ecdsa/struct.Signer.html
-//! [yubihsm::ed25519::Signer]: https://docs.rs/yubihsm/latest/yubihsm/ed25519/struct.Signer.html
 //! [Signer]: https://docs.rs/signatory/latest/signatory/trait.Signer.html
 //! [DigestSigner]: https://docs.rs/signatory/latest/signatory/trait.DigestSigner.html
 //! [Verifier]: https://docs.rs/signatory/latest/signatory/trait.Verifier.html


### PR DESCRIPTION
It no longer depends on `signatory`